### PR TITLE
Note libgimp2.0-dev dependency option

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ Thanks all GIMP developers, because they give us a great Image Manipulation Prog
 INSTALL
 ===================
 
-!!! Be sure that you have installed the gimp-devel-tools package before install.
+!!! Be sure that you have installed the gimp-devel-tools (or libgimp2.0-dev) package before install.
 
 method 1 - install into mathine directory:
 


### PR DESCRIPTION
Hi there!  I was trying to install this plugin into Gimp 2.8.16 on Ubuntu 16.04 LTS, and couldn't find the `gimp-devel-tools` package for my platform - in fact, it doesn't seem to have a proper home for any platform, and might be deprecated?  But I tried the build anyway and on a hunch I installed [`libgimp2.0-dev`](http://packages.ubuntu.com/search?keywords=libgimp2.0-dev&searchon=names), and it seems to work great.  This change just updates the readme to mention `libgimp2.0-dev` as an alternative to `gimp-devel-tools`. Thanks!